### PR TITLE
bump the sbt version because of CVE-2021-44228 and CVE-2021-45046

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.7
+sbt.version=1.5.8

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.5.7


### PR DESCRIPTION
based on this information https://scala-lang.org/blog-detail/2021/12/16/state-of-log4j-in-scala-ecosystem.html I just bumped the sbt version to avoid any potential risk 