### PR TITLE
Remove unused --split-product-types flag (close #105)

### DIFF
--- a/src/main/scala/com.snowplowanalytics.iglu/ctl/Command.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/ctl/Command.scala
@@ -67,7 +67,6 @@ object Command {
   val varcharSize = Opts.option[Int]("varchar-size", "Default size for varchar data type", metavar = "n").withDefault(4096)
   val withJsonPathsOpt = Opts.flag("with-json-paths", "Produce JSON Paths files with DDL").orFalse
   val rawMode = Opts.flag("raw-mode", "Produce raw DDL without Snowplow-specific data").orFalse
-  val splitProduct = Opts.flag("raw-mode", "Split product types (e.g. [string,integer]) into separate columns").orFalse
   val noHeader = Opts.flag("no-header", "Do not place header comments into output DDL").orFalse
   val force = Opts.flag("force", "Force override existing manually-edited files").orFalse
 
@@ -128,7 +127,7 @@ object Command {
 
   // subcommands
   val staticGenerate = Opts.subcommand("generate", "Generate DDL and JSON Path files") {
-    (input, output.orNone, dbschema, owner, varcharSize, withJsonPathsOpt, rawMode, splitProduct, noHeader, force).mapN(StaticGenerate.apply)
+    (input, output.orNone, dbschema, owner, varcharSize, withJsonPathsOpt, rawMode, noHeader, force).mapN(StaticGenerate.apply)
   }
   val staticDeploy = Opts.subcommand("deploy", "Master command for schema deployment")(Opts.argument[Path]("config").map(StaticDeploy))
   val staticPush = Opts.subcommand("push", "Upload Schemas from folder onto the Iglu Server") {
@@ -177,7 +176,6 @@ object Command {
                             varcharSize: Int,
                             withJsonPaths: Boolean,
                             rawMode: Boolean,
-                            splitProduct: Boolean,
                             noHeader: Boolean,
                             force: Boolean) extends StaticCommand
   case class StaticDeploy(config: Path) extends StaticCommand

--- a/src/main/scala/com.snowplowanalytics.iglu/ctl/Main.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/ctl/Main.scala
@@ -52,8 +52,8 @@ object Main extends IOApp {
       case Right(Command.Lint(input, skipWarnings, skipChecks)) =>
         Lint.process(input, skipChecks, skipWarnings)
 
-      case Right(Command.StaticGenerate(in, out, schema, own, size, jp, raw, split, noheader, f)) =>
-        Generate.process(in, out, jp, raw, schema, size, split, noheader, f, own)
+      case Right(Command.StaticGenerate(in, out, schema, own, size, jp, raw, noheader, f)) =>
+        Generate.process(in, out, jp, raw, schema, size, noheader, f, own)
       case Right(Command.StaticPush(input, registryRoot, apikey, public, legacy)) =>
         Push.process(input, registryRoot, apikey, public, legacy)
       case Right(Command.StaticPull(output, registryRoot, apikey)) =>

--- a/src/main/scala/com.snowplowanalytics.iglu/ctl/commands/Deploy.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/ctl/commands/Deploy.scala
@@ -47,7 +47,7 @@ object Deploy {
       output       <- Lint.process(cfg.lint.input, cfg.lint.skipChecks, cfg.lint.skipWarnings)
       _            <- Generate.process(cfg.generate.input,
         cfg.generate.output, cfg.generate.withJsonPaths, cfg.generate.rawMode,
-        cfg.generate.dbSchema, cfg.generate.varcharSize, cfg.generate.splitProduct,
+        cfg.generate.dbSchema, cfg.generate.varcharSize,
         cfg.generate.noHeader, cfg.generate.force, cfg.generate.owner)
       actionsOut   <- cfg.actions.traverse[EitherT[IO, NonEmptyList[Common.Error], *], List[String]](_.process)
     } yield output ::: actionsOut.flatten
@@ -134,7 +134,7 @@ object Deploy {
         owner         <- cursor.downField("owner").as[String]
       } yield Command.StaticGenerate(
         tempPath, Some(output), dbSchema, Some(owner),
-        varcharSize, withJsonPaths, false, false, noHeader, force
+        varcharSize, withJsonPaths, false, noHeader, force
       )
     }
 

--- a/src/main/scala/com.snowplowanalytics.iglu/ctl/commands/Generate.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/ctl/commands/Generate.scala
@@ -50,7 +50,6 @@ object Generate {
               rawMode: Boolean,
               dbSchema: String,
               varcharSize: Int,
-              splitProduct: Boolean,
               noHeader: Boolean,
               force: Boolean,
               owner: Option[String]): Result = {
@@ -62,7 +61,7 @@ object Generate {
       schemaFiles <- EitherT(File.readSchemas(input).map(Common.leftBiasedIor))
       igluSchemas = parseSchemas(schemaFiles.map(_.content)).leftMap(NonEmptyList.one)
       schemas     <- EitherT.fromEither[IO](igluSchemas)
-      result      = transform(withJsonPaths, dbSchema, varcharSize, splitProduct, noHeader, owner, rawMode)(schemas)
+      result      = transform(withJsonPaths, dbSchema, varcharSize, noHeader, owner, rawMode)(schemas)
       messages    <- EitherT(outputResult(output, result, force))
     } yield messages
   }
@@ -182,7 +181,6 @@ object Generate {
   private[ctl] def transform(withJsonPaths: Boolean,
                              dbSchema: String,
                              varcharSize: Int,
-                             splitProduct: Boolean,
                              noHeader: Boolean,
                              owner: Option[String],
                              rawMode: Boolean)

--- a/src/test/scala/com/snowplowanalytics/iglu/ctl/commands/DeploySpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/ctl/commands/DeploySpec.scala
@@ -71,7 +71,7 @@ class DeploySpec extends Specification { def is = s2"""
       ),
       Command.StaticGenerate(
         inputPath, Some(outputPath), "atomic", Some("a_new_owner"), 4096, true,
-        false, false, false, false
+        false, false, false
       ),
       List(
         IgluctlAction.Push(Command.StaticPush(

--- a/src/test/scala/com/snowplowanalytics/iglu/ctl/commands/GenerateSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/ctl/commands/GenerateSpec.scala
@@ -166,7 +166,7 @@ class GenerateSpec extends Specification { def is = s2"""
          |
          |COMMENT ON TABLE atomic.com_amazon_aws_lambda_java_context_1 IS 'iglu:com.amazon.aws.lambda/java_context/jsonschema/1-0-0';""".stripMargin
 
-    val output = Generate.transform(false, "atomic", 4096, false, true, None, false)(NonEmptyList.of(input))
+    val output = Generate.transform(false, "atomic", 4096, true, None, false)(NonEmptyList.of(input))
     val expected = Generate.DdlOutput(
       List(textFile(Paths.get("com.amazon.aws.lambda/java_context_1.sql"), expectedDdl)),
       Nil, Nil, Nil
@@ -286,7 +286,7 @@ class GenerateSpec extends Specification { def is = s2"""
         }
       """.schema
 
-    val output = Generate.transform(false, "atomic", 128, false, true, None, true)(NonEmptyList.of(input))
+    val output = Generate.transform(false, "atomic", 128, true, None, true)(NonEmptyList.of(input))
     val expected = List(textFile(Paths.get("com.amazon.aws.lambda/java_context_1.sql"), resultContent))
 
     output.ddls must beEqualTo(expected)
@@ -403,7 +403,7 @@ class GenerateSpec extends Specification { def is = s2"""
            "additionalProperties" : false
          }""".schema
 
-    val output = Generate.transform(false, "snowplow", 4096, false, true, None, false)(NonEmptyList.of(input))
+    val output = Generate.transform(false, "snowplow", 4096, true, None, false)(NonEmptyList.of(input))
     val expected = Generate.DdlOutput(
       List(textFile(Paths.get("com.amazon.aws.ec2/instance_identity_document_1.sql"), resultContent)),
       Nil, Nil, Nil
@@ -552,7 +552,7 @@ class GenerateSpec extends Specification { def is = s2"""
          |    ]
          |}""".stripMargin
 
-    val output = Generate.transform(true, "atomic", 4096, false, false, None, false)(NonEmptyList.of(input)).jsonPaths.head
+    val output = Generate.transform(true, "atomic", 4096, false, None, false)(NonEmptyList.of(input)).jsonPaths.head
 
     val expected = textFile(Paths.get("com.amazon.aws.cloudfront/wd_access_log_1.json"), resultContent)
 
@@ -657,7 +657,7 @@ class GenerateSpec extends Specification { def is = s2"""
          |
          |ALTER TABLE atomic.com_acme_persons_simple_1 OWNER TO storageloader;""".stripMargin
 
-    val output = Generate.transform(false, "atomic", 4096, false, true, Some("storageloader"), true)(NonEmptyList.of(input))
+    val output = Generate.transform(false, "atomic", 4096, true, Some("storageloader"), true)(NonEmptyList.of(input))
 
     val expected = List(textFile(Paths.get("com.acme.persons/simple_1.sql"), resultContent))
 
@@ -748,7 +748,7 @@ class GenerateSpec extends Specification { def is = s2"""
         |
         |END TRANSACTION;""".stripMargin
 
-    val output = Generate.transform(false, "atomic", 4096, false, true, None, false)(NonEmptyList.of(initial, second))
+    val output = Generate.transform(false, "atomic", 4096, true, None, false)(NonEmptyList.of(initial, second))
     val expected = Generate.DdlOutput(
       List(textFile(Paths.get("com.acme/example_1.sql"), expectedDdl)),
       List(textFile(Paths.get("com.acme/example/1-0-0/1-0-1.sql"), expectedMigration)),
@@ -1067,7 +1067,7 @@ class GenerateSpec extends Specification { def is = s2"""
         |
         |END TRANSACTION;""".stripMargin
 
-    val output = Generate.transform(false, "atomic", 4096, false, true, None, false)(NonEmptyList.of(initial, second, third))
+    val output = Generate.transform(false, "atomic", 4096, true, None, false)(NonEmptyList.of(initial, second, third))
     val expected = Generate.DdlOutput(
       List(textFile(Paths.get("com.acme/example_1.sql"), expectedDdl)),
       List(
@@ -1136,7 +1136,7 @@ class GenerateSpec extends Specification { def is = s2"""
 
     val expected = Generate.DdlOutput(List(textFile(Paths.get("com.acme/example_1.sql"), expectedDdl)), Nil, Nil, Nil)
 
-    val output = Generate.transform(false, "atomic", 4096, false, true, None, false)(NonEmptyList.of(schema))
+    val output = Generate.transform(false, "atomic", 4096, true, None, false)(NonEmptyList.of(schema))
 
     output must beEqualTo(expected)
   }
@@ -1198,7 +1198,7 @@ class GenerateSpec extends Specification { def is = s2"""
 
     val expected = Generate.DdlOutput(List(textFile(Paths.get("com.acme/example_1.sql"), expectedDdl)), Nil, Nil, Nil)
 
-    val output = Generate.transform(false, "atomic", 4096, false, true, None, false)(NonEmptyList.of(schema))
+    val output = Generate.transform(false, "atomic", 4096, true, None, false)(NonEmptyList.of(schema))
 
     output must beEqualTo(expected)
   }
@@ -1246,7 +1246,7 @@ class GenerateSpec extends Specification { def is = s2"""
 
     val expected = Generate.DdlOutput(List(textFile(Paths.get("com.acme/example_1.sql"), expectedDdl)), Nil, Nil, Nil)
 
-    val output = Generate.transform(false, "atomic", 4096, false, true, None, false)(NonEmptyList.of(schema))
+    val output = Generate.transform(false, "atomic", 4096, true, None, false)(NonEmptyList.of(schema))
 
     output must beEqualTo(expected)
   }
@@ -1289,7 +1289,7 @@ class GenerateSpec extends Specification { def is = s2"""
 
     val expected = Generate.DdlOutput(List(textFile(Paths.get("com.acme/example_1.sql"), expectedDdl)), Nil, Nil, Nil)
 
-    val output = Generate.transform(false, "atomic", 4096, false, true, None, false)(NonEmptyList.of(schema))
+    val output = Generate.transform(false, "atomic", 4096, true, None, false)(NonEmptyList.of(schema))
 
     output must beEqualTo(expected)
   }
@@ -1347,7 +1347,7 @@ class GenerateSpec extends Specification { def is = s2"""
         }
       """.schema
 
-    val output = Generate.transform(false, "atomic", 4096, false, true, None, false)(NonEmptyList.of(input1, input2))
+    val output = Generate.transform(false, "atomic", 4096, true, None, false)(NonEmptyList.of(input1, input2))
 
     val expectedWarning = "Gap in the following model group schemas, NonEmptyList(SchemaKey(com.amazon.aws.lambda,java_context,jsonschema,Full(1,0,0)), SchemaKey(com.amazon.aws.lambda,java_context,jsonschema,Full(1,0,2)))"
 


### PR DESCRIPTION
See https://github.com/snowplow-incubator/igluctl/issues/105

This change would also require 

- [x]  updating the [docs](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/igluctl-2/#static-generate) which reference `--split-product-types`
