### PR TITLE
Bump aws s3 & jackson-databind and remove doobie-postgres 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,7 @@ lazy val root = project.in(file("."))
     libraryDependencies ++= Seq(
       // Java
       Libraries.awsJava,
+      Libraries.jacksonDatabind,
       // Scala
       Libraries.circeParser,
       Libraries.circeConfig,

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,6 @@ lazy val root = project.in(file("."))
       Libraries.fs2,
       Libraries.fs2Io,
       Libraries.doobieCore,
-      Libraries.doobiePostgres,
       Libraries.logback,
       // Scala (test only)
       Libraries.specs2,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
 
   object V {
     // Java
-    val awsJava          = "2.17.13"
+    val awsJava          = "2.17.213"
     // Scala
     val circe            = "0.14.1"
     val circeConfig      = "0.8.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,6 +17,7 @@ object Dependencies {
   object V {
     // Java
     val awsJava          = "2.17.213"
+    val jackson          = "2.12.7"
     // Scala
     val circe            = "0.14.1"
     val circeConfig      = "0.8.0"
@@ -36,6 +37,8 @@ object Dependencies {
   object Libraries {
     // Java
     val awsJava          = "software.amazon.awssdk"     %  "s3"                        % V.awsJava
+    val jacksonDatabind  = "com.fasterxml.jackson.core" % "jackson-databind"           % V.jackson // override transitive version to address security vulnerabilities
+
     // Scala
     val circeParser      = "io.circe"                   %% "circe-jawn"                % V.circe
     val circeConfig      = "io.circe"                   %% "circe-config"              % V.circeConfig

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -50,7 +50,6 @@ object Dependencies {
     val fs2              = "co.fs2"                     %% "fs2-core"                  % V.fs2
     val fs2Io            = "co.fs2"                     %% "fs2-io"                    % V.fs2
     val doobieCore       = "org.tpolecat"               %% "doobie-core"               % V.doobie
-    val doobiePostgres   = "org.tpolecat"               %% "doobie-postgres"           % V.doobie
     val logback          = "ch.qos.logback"             % "logback-classic"            % V.logback % Runtime
     // Scala (test only)
     val specs2           = "org.specs2"                 %% "specs2-core"               % V.specs2         % "test"


### PR DESCRIPTION
See:
https://github.com/snowplow-incubator/igluctl/issues/120
https://github.com/snowplow-incubator/igluctl/issues/121
https://github.com/snowplow-incubator/igluctl/issues/122

In addition to checking that igluctl still compiles and tests still work, I will do some sanity check sort of manual testing.

We should test:
- any commands using the aws library that was bumped (`igluctl static s3cp`)
- anything using iglu scala client, as we are manually bumping jackson databind which is a dependency of iglu scala client (`igluctl table-check` and `igluctl lint`)

Test cases: 
### `igluctl lint`
I ran `igluctl lint /Users/leigh-anne/code/iglu-central/schemas/com.twitter/SerializedBlock/protobuf/1-0-0` on this branch `bump-deps-june-22` and on `develop` for two schemas, one with warnings and one without and compared the output

output [here](https://gist.github.com/lmath/35e5f8895429c059b1332ad88a97e9ec) 

### `igluctl static s3cp`
compared running `igluctl static s3cp /Users/leigh-anne/schemas lm-test-bucket-can-delete` and it came out as expected 
output [here](https://gist.github.com/lmath/4eec761a1f95b1c429fbf5643fa0769e)

### `igluctl table-check`
```
igluctl rdbms table-check --resolver /Users/leigh-anne/code/enrich/modules/kinesis/src/it/resources/iglu_resolver.json --schema iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-0 --host <aws_redshift_prod1 host> --dbname snowplow --username <user> --password <password>

output on branch bump-deps-june-22
Matched:
Table for iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-0 is matched
Unmatched: 0, Comment issues: 0, Matched: 1, Not Deployed: 0

output on develop
Matched:
Table for iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-0 is matched
Unmatched: 0, Comment issues: 0, Matched: 1, Not Deployed: 0
```
Thanks to Dilyan for this table-check test case. I just reproduced it here.
Note: I mistakenly added extra test cases here previously, which I've dumped into a [gist](https://gist.github.com/lmath/eb4ce556e415977a30a2eb678f86aabf) in case they are handy later