### PR TITLE
Drop support for iglu-server <0.6.0 (close #127)

### DIFF
--- a/src/main/scala/com.snowplowanalytics.iglu/ctl/Command.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/ctl/Command.scala
@@ -80,7 +80,6 @@ object Command {
   val registryRoot = Opts.argument[Server.HttpUrl]("uri")
   val apikey = Opts.argument[UUID]("uuid")
   val public = Opts.flag("public", "Upload schemas as public").orFalse
-  val legacy = Opts.flag("legacy", "Upload schemas with master API key (for pre-0.6.0 Server)").orFalse
 
   // static s3cp options
   type S3Path = String
@@ -137,7 +136,7 @@ object Command {
   }
   val staticDeploy = Opts.subcommand("deploy", "Master command for schema deployment")(Opts.argument[Path]("config").map(StaticDeploy))
   val staticPush = Opts.subcommand("push", "Upload Schemas from folder onto the Iglu Server") {
-    (input, registryRoot, apikey, public, legacy).mapN(StaticPush.apply)
+    (input, registryRoot, apikey, public).mapN(StaticPush.apply)
   }
   val staticPull = Opts.subcommand("pull", "Download schemas from Iglu Server to local folder") {
     (output, registryRoot, apikey.orNone).mapN(StaticPull.apply)
@@ -188,8 +187,7 @@ object Command {
   case class StaticPush(input: Path,
                         registryRoot: Server.HttpUrl,
                         apikey: UUID,
-                        public: Boolean,
-                        legacy: Boolean) extends StaticCommand
+                        public: Boolean) extends StaticCommand
   case class StaticPull(output: Path,
                         registryRoot: Server.HttpUrl,
                         apikey: Option[UUID]) extends StaticCommand

--- a/src/main/scala/com.snowplowanalytics.iglu/ctl/commands/Deploy.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/ctl/commands/Deploy.scala
@@ -161,7 +161,7 @@ object Deploy {
             secret       <- cursor.downField("apikey").as[ApiKeySecret]
             masterApiKey <- secret.value.leftMap(e => DecodingFailure(e.toString, cursor.history))
             isPublic     <- cursor.downField("isPublic").as[Boolean]
-          } yield IgluctlAction.Push(Command.StaticPush(tempPath, registryRoot, masterApiKey, isPublic, false))
+          } yield IgluctlAction.Push(Command.StaticPush(tempPath, registryRoot, masterApiKey, isPublic))
         case Right(unknown) =>
           DecodingFailure(s"Unknown IgluCtl action: $unknown", cursor.history).asLeft
         case Left(e) =>

--- a/src/test/scala/com/snowplowanalytics/iglu/ctl/CommandSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/ctl/CommandSpec.scala
@@ -51,7 +51,7 @@ class CommandSpec extends Specification { def is = s2"""
     val staticPush = Command.parse("static push .. http://54.165.217.26:8081/ 1af851ab-ef1b-4109-a8e2-720ac706334c --public".split(" ").toList)
 
     val url = Server.HttpUrl.parse("http://54.165.217.26:8081/").getOrElse(throw new RuntimeException("Invalid URI"))
-    staticPush must beRight(Command.StaticPush(Paths.get(".."), url, UUID.fromString("1af851ab-ef1b-4109-a8e2-720ac706334c"), true, false))
+    staticPush must beRight(Command.StaticPush(Paths.get(".."), url, UUID.fromString("1af851ab-ef1b-4109-a8e2-720ac706334c"), true))
   }
 
   def e3 = {

--- a/src/test/scala/com/snowplowanalytics/iglu/ctl/commands/DeploySpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/ctl/commands/DeploySpec.scala
@@ -82,8 +82,7 @@ class DeploySpec extends Specification { def is = s2"""
         IgluctlAction.Push(Command.StaticPush(
           inputPath, Server.HttpUrl(uri"http://iglu-server.com"),
           UUID.fromString("79f28002-aadc-4bdf-bd79-7209f28873b9"),
-          true,
-          false
+          true
         )),
         IgluctlAction.S3Cp(Command.StaticS3Cp(
           inputPath, "bucket", Some("path_1/path_2"),
@@ -91,7 +90,6 @@ class DeploySpec extends Specification { def is = s2"""
         ))
       )
     )
-
 
     val result = config.as[IgluctlConfig]
     result must beRight(expected)


### PR DESCRIPTION
See https://github.com/snowplow-incubator/igluctl/issues/127

This means 
- [x] existing tests should pass
- [x] `igluctl static push` should still push files for a recent version of iglu-server
brought up an iglu server by following [this readme](https://github.com/snowplow-incubator/iglu-server/blob/master/docker/README.md)
ran `igluctl static push /Users/leigh-anne/schemas localhost:8080 <default api key>`
saw this expected output
![image](https://user-images.githubusercontent.com/3072877/177178527-e1b1f8ca-2f4b-499b-b70c-dbf8457dc655.png)

and then saw the schemas with
`curl --location --request GET 'http://localhost:8080/api/schemas' \
--header 'apikey: <default api key>'`
- [x] `igluctl server keygen` should still generate keys that can be used with the server

ran `igluctl server keygen --vendor-prefix com.test1 localhost:8080 <default api key>`
and saw some nice uuids where the read key allowed me to fetch schemas with prefix `com.test1` 
`curl --location --request GET 'http://localhost:8080/api/schemas' \
--header 'apikey: c21e2869-a1c8-48a3-a7e0-67d00f0657ac'`

showed me the schema I know is on the local server with that prefix
```
[
    "iglu:com.test1/anonymous_ip/jsonschema/1-0-0"
]
```
and the write key allowed me to add a schema with prefix `com.test1`
```
curl --location --request POST 'http://localhost:8080/api/schemas' \
--header 'apikey: ebb23ea3-a8f3-4466-aa59-fd0d7c5a0962' \
--header 'Content-Type: text/plain' \
--data-raw '{
  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
  "description": "Schema for a test1 coffee order",
  "self": {
    "vendor": "com.test1",
    "name": "order_placed",
    "format": "jsonschema",
    "version": "1-0-0"
  },
  "type": "object",
  "properties": {
    "order": {
      "type": "string"
    },
    "modifier": {
      "type": "string",
      "minLength": 1
    }
  },
  "required": ["order"],
  "additionalProperties": true
}'
```
gives me 201 created
```
{
    "message": "Schema created",
    "updated": false,
    "location": "iglu:com.test1/order_placed/jsonschema/1-0-0",
    "status": 201
}
```

- [x] searching for 0.6.0 in the igluctl codebase should just return results in the changelog
- [x] passing `--legacy` to `igluctl static push` should error
![image](https://user-images.githubusercontent.com/3072877/177181127-62f94c05-7a80-4330-8a5c-9876f00f0c58.png)

